### PR TITLE
fix: npm issue with .venv directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -181,7 +181,9 @@ export default {
   // verbose: undefined,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-  // watchPathIgnorePatterns: [],
+  watchPathIgnorePatterns: [
+    ".venv/.*"
+  ],
 
   // Whether to use watchman for file crawling
   // watchman: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,9 @@ function defineConfig({ mode }) {
   return {
     server: {
       port: 3000,
+      watch : {
+        ignored: ['**/.venv/**']
+      }
     },
     build: {
       outDir: 'build',


### PR DESCRIPTION
## Goal
Fix error:
![image](https://github.com/user-attachments/assets/8aec5dd6-21b2-479e-bc5c-1906f3dbcc83)

### Notes
.venv directory is qa environment, the same as node_modules but for qa