### PR TITLE
fix: update mock-server configuration to disable logging and specify port protocol

### DIFF
--- a/docker-compose.qa.yaml
+++ b/docker-compose.qa.yaml
@@ -86,12 +86,12 @@ services:
     networks:
       - qa-la-net
     environment:
-      MOCKSERVER_LOG_LEVEL: DEBUG
+      MOCKSERVER_LOG_LEVEL: OFF
       MOCKSERVER_PROPERTY_FILE: /config/mockserver.properties
     volumes:
       - ./tests/tools/mock-server-new/mockserver.properties:/config/mockserver.properties
     expose:
-      - "8091"
+      - "8091/tcp"
     ports:
       - "8091:8091"
 

--- a/tests/tools/mock-server-new/mockserver.properties
+++ b/tests/tools/mock-server-new/mockserver.properties
@@ -7,3 +7,4 @@ mockserver.corsAllowHeaders=accept, accept-encoding, authorization, content-type
 mockserver.corsMaxAgeInSeconds=300
 
 mockserver.maxSocketTimeout=120000
+mockserver.logLevel=OFF


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.qa.yaml` file to adjust the configuration of the MockServer service. The most important changes are related to the logging level and network exposure settings.

Configuration updates for MockServer:

* Changed the `MOCKSERVER_LOG_LEVEL` environment variable from `DEBUG` to `OFF` to reduce logging verbosity.
* Updated the `expose` directive to specify the protocol explicitly, changing `"8091"` to `"8091/tcp"`.