### PR TITLE
fix: update password placeholder in configuration files

### DIFF
--- a/tests/acceptance/docs/utils/template-local-toolium.cfg
+++ b/tests/acceptance/docs/utils/template-local-toolium.cfg
@@ -74,7 +74,7 @@ port: 4444
 base_path: /wd/hub
 # User and password for basic authentication
 username: test_tef
-password: qa-grid-ggr
+password: TO_BE_DEFINED
 # Video and logs
 video_enabled: false
 logs_enabled: true

--- a/tests/acceptance/settings/toolium.cfg
+++ b/tests/acceptance/settings/toolium.cfg
@@ -83,7 +83,7 @@ port: 4444
 base_path: /wd/hub
 # User and password for basic authentication
 username: test_tef
-password: qa-grid-ggr
+password: TO_BE_DEFINED
 # Video and logs
 video_enabled: false
 logs_enabled: true


### PR DESCRIPTION
This pull request updates configuration files to replace sensitive information with placeholders for better security practices.

Security updates:

* [`tests/acceptance/docs/utils/template-local-toolium.cfg`](diffhunk://#diff-b81080ad3b223b6cda40fbdc5943914407f3c1cce367fe5eadd0dcda049d12e7L77-R77): Updated the `password` field from `qa-grid-ggr` to `TO_BE_DEFINED`.
* [`tests/acceptance/settings/toolium.cfg`](diffhunk://#diff-fb94b6153b45007f60c2cf27a8562e0f9c8d13268b5560d49ab3bb1f466bebc9L86-R86): Updated the `password` field from `qa-grid-ggr` to `TO_BE_DEFINED`.